### PR TITLE
Added labels to image build to address red hat certification failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ MAINTAINER ManageIQ https://github.com/ManageIQ/manageiq-appliance-build
 LABEL io.k8s.description="Memcached is a general-purpose distributed memory object caching system" \
       io.k8s.display-name="Memcached" \
       io.openshift.expose-services="11211:memcached" \
-      io.openshift.tags="memcached"
+      io.openshift.tags="memcached" \
+      name="Memcached" \
+      summary="Memcached Image" \
+      vendor="ManageIQ" \
+      description="Memcached is a general-purpose distributed memory object caching system"
 
 EXPOSE 11211
 


### PR DESCRIPTION
Addresses these failures -
![image](https://user-images.githubusercontent.com/76593/109553017-7fa7ee00-7aa0-11eb-907c-a52715e03287.png)
