### PR TITLE
Set user by id rather than name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ COPY container-assets/container-entrypoint /usr/bin
 RUN mkdir -p /opt/manageiq/manifest
 COPY --from=manifest /tmp/BUILD /opt/manageiq/manifest
 
-USER memcached
+USER 998
 ENTRYPOINT ["container-entrypoint"]
 CMD ["memcached"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY container-assets/container-entrypoint /usr/bin
 RUN mkdir -p /opt/manageiq/manifest
 COPY --from=manifest /tmp/BUILD /opt/manageiq/manifest
 
+# memcached user is uid 998
 USER 998
 ENTRYPOINT ["container-entrypoint"]
 CMD ["memcached"]


### PR DESCRIPTION
Error in K3s:
```
 Warning  Failed     10s (x9 over 94s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (memcached), cannot verify user is non-root (pod: "memcached-7b5bc5bdf4-rkm96_manageiq(0e998fc7-e0f0-46bc-ba5a-5985c312eeaa)", container: memcached)
```