### PR TITLE
Revert "Lock down to ubi8.8-1032"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cd /tmp && \
     if [[ "$(cat .git/HEAD)" == "ref:"* ]]; then sha=$(cat .git/$sha); fi && \
     echo "$(date +"%Y%m%d%H%M%S")-$sha" > /tmp/BUILD
 
-FROM registry.access.redhat.com/ubi8/ubi:8.8-1032
+FROM registry.access.redhat.com/ubi8/ubi
 
 # Memcached image for OpenShift ManageIQ
 


### PR DESCRIPTION
This reverts commit 661436a4796f193776a696fa4ee69cc91bf27e98.

A new UBI8 image has been released.  The yum repos are available on ppc64le now.