### PR TITLE
Revert "Temporarily lock down to 10.2 due to signature issues on s390x latest"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS manifest
+FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS manifest
 
 COPY .git /tmp/.git
 


### PR DESCRIPTION
This reverts commit d2bb4972521e8f7e0aaf7ec62602a51a0a36cfcc.

A new UBI was published and the signatures are now valid.
https://github.com/ManageIQ/manageiq/issues/23855